### PR TITLE
🎨 Palette: Add explicit label associations to contact form

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -57,8 +57,9 @@ export default function Contact() {
 
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
                                 <div className="space-y-2 text-left relative group">
-                                    <label className="text-sm font-bold uppercase tracking-widest opacity-60 group-focus-within:text-mustard transition-colors duration-300">Name</label>
+                                    <label htmlFor="name" className="text-sm font-bold uppercase tracking-widest opacity-60 group-focus-within:text-mustard transition-colors duration-300">Name</label>
                                     <input
+                                        id="name"
                                         name={contactData.contactForm.fieldIds.name}
                                         type="text"
                                         required
@@ -68,8 +69,9 @@ export default function Contact() {
                                     <span className="absolute bottom-0 left-0 w-0 h-[1.5px] bg-mustard group-focus-within:w-full transition-all duration-500"></span>
                                 </div>
                                 <div className="space-y-2 text-left relative group">
-                                    <label className="text-sm font-bold uppercase tracking-widest opacity-60 group-focus-within:text-mustard transition-colors duration-300">Email</label>
+                                    <label htmlFor="email" className="text-sm font-bold uppercase tracking-widest opacity-60 group-focus-within:text-mustard transition-colors duration-300">Email</label>
                                     <input
+                                        id="email"
                                         name={contactData.contactForm.fieldIds.email}
                                         type="email"
                                         required
@@ -80,8 +82,9 @@ export default function Contact() {
                                 </div>
                             </div>
                             <div className="space-y-2 text-left relative group">
-                                <label className="text-sm font-bold uppercase tracking-widest opacity-60 group-focus-within:text-mustard transition-colors duration-300">Message</label>
+                                <label htmlFor="message" className="text-sm font-bold uppercase tracking-widest opacity-60 group-focus-within:text-mustard transition-colors duration-300">Message</label>
                                 <textarea
+                                    id="message"
                                     name={contactData.contactForm.fieldIds.message}
                                     rows="1"
                                     required


### PR DESCRIPTION
💡 **What:** Added `htmlFor` and `id` attributes to correctly associate labels with their corresponding inputs (`name`, `email`, `message`) in the `Contact` component.
🎯 **Why:** To improve form accessibility (a11y) and usability by allowing screen-readers to associate the form control correctly, and expanding the clickable area of inputs to the labels themselves.
♿ **Accessibility:** Fixes programmatic association of labels for input and textarea controls, adhering to WCAG guidelines.

---
*PR created automatically by Jules for task [16517813212584755476](https://jules.google.com/task/16517813212584755476) started by @ANAGHAKTP*