### PR TITLE
🛡️ Sentinel: [MEDIUM] Add standard HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-06-11 - Add Default Security Headers
+**Vulnerability:** Missing standard HTTP security headers.
+**Learning:** Next.js doesn't apply these by default. Clickjacking, XSS, and MIME-sniffing protections should be explicitly defined in `next.config.mjs` for statically exported or deployed Next.js apps to establish a defense in depth baseline.
+**Prevention:** Include a standard set of security headers (`Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `Permissions-Policy`, `Referrer-Policy`, `X-XSS-Protection`) in the `next.config.mjs` template when initiating new Next.js projects.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,39 @@
 const nextConfig = {
   /* config options here */
   reactCompiler: true,
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-XSS-Protection',
+            value: '1; mode=block',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard HTTP security headers, leaving the application potentially vulnerable to clickjacking, MIME-type sniffing, and cross-site scripting (XSS) via lack of defense-in-depth protections.
🎯 Impact: Attackers could potentially embed the site in malicious iframes, sniff content types, or exploit other client-side vulnerabilities if defenses fail.
🔧 Fix: Added a comprehensive suite of security headers (`X-Content-Type-Options`, `X-Frame-Options`, `X-XSS-Protection`, `Referrer-Policy`, `Strict-Transport-Security`, `Permissions-Policy`) to `next.config.mjs` applied globally to all routes.
✅ Verification: Ran `pnpm lint` and `pnpm build` successfully. The headers will be present on all HTTP responses.

---
*PR created automatically by Jules for task [7958425601056329620](https://jules.google.com/task/7958425601056329620) started by @ANAGHAKTP*