### PR TITLE
🎨 Palette: Improve accessibility of Hero scroll down indicators

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-18 - Making Decorative Circular SVG Links Accessible
+**Learning:** Circular animated text built with SVG `<textPath>` inside an anchor tag is read incorrectly and redundantly by screen readers, creating a confusing experience when combined with an arrow icon.
+**Action:** Always add `aria-hidden="true"` to such decorative SVG elements and provide a single, clear `aria-label` (e.g., "Scroll down to about section") on the parent `<a>` element, along with proper `focus-visible` styles for keyboard navigation.

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -132,8 +132,8 @@ export default function Hero() {
 
             {/* Scroll Down Indicator */}
             <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-20 flex flex-col items-center space-y-4 lg:hidden">
-                <a href="#about" className="w-24 h-24 rounded-full border border-cream/20 flex items-center justify-center relative group active:border-mustard/30">
-                    <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
+                <a aria-label="Scroll down to about section" href="#about" className="w-24 h-24 rounded-full border border-cream/20 flex items-center justify-center relative group active:border-mustard/30 focus-visible:ring-2 focus-visible:ring-mustard focus-visible:outline-none">
+                    <svg aria-hidden="true" viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
                         <path id="circlePathMobile" d="M 50, 50 m -35, 0 a 35,35 0 1,1 70,0 a 35,35 0 1,1 -70,0" fill="transparent" />
                         <text className="text-[8px] uppercase font-sans font-bold tracking-[0.18em] fill-cream">
                             <textPath href="#circlePathMobile" startOffset="0%">
@@ -142,7 +142,7 @@ export default function Hero() {
                         </text>
                     </svg>
                     <div className="w-7 h-7 rounded-full bg-mustard/10 flex items-center justify-center">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-mustard">
+                        <svg aria-hidden="true" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-mustard">
                             <path d="M12 5v14M19 12l-7 7-7-7" />
                         </svg>
                     </div>
@@ -151,8 +151,8 @@ export default function Hero() {
 
             {/* Desktop Scroll Indicator */}
             <div className="absolute bottom-10 right-20 hidden lg:block z-20">
-                <a href="#about" className="w-32 h-32 rounded-full border border-cream/10 flex items-center justify-center relative group hover:border-mustard/30 transition-all duration-300">
-                    <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
+                <a aria-label="Scroll down to about section" href="#about" className="w-32 h-32 rounded-full border border-cream/10 flex items-center justify-center relative group hover:border-mustard/30 transition-all duration-300 focus-visible:ring-2 focus-visible:ring-mustard focus-visible:outline-none">
+                    <svg aria-hidden="true" viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
                         <path id="circlePath" d="M 50, 50 m -38, 0 a 38,38 0 1,1 76,0 a 38,38 0 1,1 -76,0" fill="transparent" />
                         <text className="text-[7.5px] uppercase font-sans font-bold tracking-[0.2em] fill-cream group-hover:fill-mustard transition-colors duration-300">
                             <textPath href="#circlePath" startOffset="0%">
@@ -161,7 +161,7 @@ export default function Hero() {
                         </text>
                     </svg>
                     <div className="w-8 h-8 rounded-full bg-mustard/10 group-hover:bg-mustard/20 flex items-center justify-center transition-all duration-300">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-mustard group-hover:translate-y-0.5 transition-transform duration-300">
+                        <svg aria-hidden="true" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-mustard group-hover:translate-y-0.5 transition-transform duration-300">
                             <path d="M12 5v14M19 12l-7 7-7-7" />
                         </svg>
                     </div>


### PR DESCRIPTION
💡 **What**: Added comprehensive accessibility enhancements to the hero section's scroll down indicators (both mobile and desktop).
🎯 **Why**: The circular text built via SVG `<textPath>` combined with an arrow icon can be confusing for screen readers and hard to navigate for keyboard-only users.
📸 **Before/After**: Visually identical to most users, but functionally far superior. Focus styles are now clearly visible when tabbing through the links.
♿ **Accessibility**: Enhanced screen reader support by hiding decorative SVGs with `aria-hidden="true"` and defining an explicit `aria-label`. Improved keyboard navigation with visible focus rings.

---
*PR created automatically by Jules for task [5618107045007959863](https://jules.google.com/task/5618107045007959863) started by @ANAGHAKTP*