### PR TITLE
🎨 Palette: Enhance keyboard focus states and screen reader accessibility

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -95,7 +95,7 @@ export default function Contact() {
                                 <span className="absolute bottom-0 left-0 w-0 h-[1.5px] bg-mustard group-focus-within:w-full transition-all duration-500"></span>
                             </div>
                             <button className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4">
-                                Send Message <span className="material-icons">east</span>
+                                Send Message <span className="material-icons" aria-hidden="true">east</span>
                             </button>
                         </form>
                     </div>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -118,7 +118,7 @@ export default function Hero() {
                                 return (
                                     <div key={social.platform} className="flex items-center space-x-6 group">
                                         <span className="w-8 h-[1px] bg-cream/20 group-hover:w-12 group-hover:bg-mustard transition-all duration-300"></span>
-                                        <a href={social.url} target="_blank" rel="noopener noreferrer" className="hover:text-mustard transition-colors flex items-center">
+                                        <a href={social.url} target="_blank" rel="noopener noreferrer" className="hover:text-mustard transition-colors flex items-center focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mustard rounded-sm" aria-label={`Visit my ${social.platform} profile`}>
                                             <span className="opacity-40 mr-1.5">{prefix}</span>
                                             <span>{handle}</span>
                                         </a>
@@ -132,8 +132,8 @@ export default function Hero() {
 
             {/* Scroll Down Indicator */}
             <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-20 flex flex-col items-center space-y-4 lg:hidden">
-                <a href="#about" className="w-24 h-24 rounded-full border border-cream/20 flex items-center justify-center relative group active:border-mustard/30">
-                    <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
+                <a href="#about" className="w-24 h-24 rounded-full border border-cream/20 flex items-center justify-center relative group active:border-mustard/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mustard" aria-label="Scroll down to About section">
+                    <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none" aria-hidden="true">
                         <path id="circlePathMobile" d="M 50, 50 m -35, 0 a 35,35 0 1,1 70,0 a 35,35 0 1,1 -70,0" fill="transparent" />
                         <text className="text-[8px] uppercase font-sans font-bold tracking-[0.18em] fill-cream">
                             <textPath href="#circlePathMobile" startOffset="0%">
@@ -151,8 +151,8 @@ export default function Hero() {
 
             {/* Desktop Scroll Indicator */}
             <div className="absolute bottom-10 right-20 hidden lg:block z-20">
-                <a href="#about" className="w-32 h-32 rounded-full border border-cream/10 flex items-center justify-center relative group hover:border-mustard/30 transition-all duration-300">
-                    <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
+                <a href="#about" className="w-32 h-32 rounded-full border border-cream/10 flex items-center justify-center relative group hover:border-mustard/30 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mustard" aria-label="Scroll down to About section">
+                    <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none" aria-hidden="true">
                         <path id="circlePath" d="M 50, 50 m -38, 0 a 38,38 0 1,1 76,0 a 38,38 0 1,1 -76,0" fill="transparent" />
                         <text className="text-[7.5px] uppercase font-sans font-bold tracking-[0.2em] fill-cream group-hover:fill-mustard transition-colors duration-300">
                             <textPath href="#circlePath" startOffset="0%">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -8,11 +8,11 @@ export default function Navbar() {
             </div>
 
             <div className="hidden md:flex items-center space-x-12 font-sans text-xs font-bold uppercase tracking-widest">
-                <a href="#about" className="hover:opacity-60 transition-opacity">About me</a>
-                <a href="#projects" className="hover:opacity-60 transition-opacity">Work</a>
+                <a href="#about" className="hover:opacity-60 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mustard focus-visible:ring-offset-2 focus-visible:ring-offset-forest rounded-sm">About me</a>
+                <a href="#projects" className="hover:opacity-60 transition-opacity focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mustard focus-visible:ring-offset-2 focus-visible:ring-offset-forest rounded-sm">Work</a>
                 <a
                     href="#contact"
-                    className="bg-mustard text-black px-8 py-3 rounded-badge hover:bg-orange-600 transition-all font-bold"
+                    className="bg-mustard text-black px-8 py-3 rounded-badge hover:bg-orange-600 transition-all font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-mustard focus-visible:ring-offset-2 focus-visible:ring-offset-forest rounded-sm"
                 >
                     Get in touch!
                 </a>


### PR DESCRIPTION
💡 **What:** Added visible focus rings for keyboard navigation to the Navbar links, social media links, and the scroll down indicators. I also added ARIA labels for icon-only scroll indicators and hid their purely decorative spinning text SVGs from screen readers.
🎯 **Why:** To improve keyboard accessibility so that users navigating the site via keyboard (using Tab) can easily see which element is currently focused. Screen reader accessibility was also improved for the scroll indicators to provide better context rather than reading out the decorative path/text.
📸 **Before/After:** The visual design for mouse users is completely unchanged. However, when navigating with a keyboard, users will now see a clear mustard-colored focus ring around interactive elements, which was previously missing or very subtle.
♿ **Accessibility:**
- Keyboard users can now clearly track their focus across the Navbar and Hero interactive elements.
- Screen readers will now appropriately announce "Scroll down to About section" for the hero scroll buttons and skip the decorative, repetitive spinning text (`aria-hidden="true"`).
- Screen readers will announce the destination for the icon-only social links.

---
*PR created automatically by Jules for task [4139402283504833535](https://jules.google.com/task/4139402283504833535) started by @ANAGHAKTP*