### PR TITLE
🛡️ Sentinel: [MEDIUM] Add HTTP security headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-11 - Added security headers in Next.js config
+**Vulnerability:** The application was missing standard HTTP security headers (e.g., X-Frame-Options, Content-Security-Policy), which could expose it to clickjacking, MIME-type sniffing, and other common web vulnerabilities.
+**Learning:** Next.js applications need explicit configuration in `next.config.mjs` to enforce security headers across all routes. The idiomatic approach is to use the `/:path*` matcher instead of regex like `/(.*)` for the source pattern. Also, running `pnpm install` to resolve linting/building issues can unexpectedly generate and track `pnpm-lock.yaml`, violating line limits.
+**Prevention:** Always verify that Next.js configurations include standard security headers by default. Be cautious of side-effects from package manager commands like `pnpm install` and revert lockfile changes if they violate strict line-limit constraints.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,35 @@
 const nextConfig = {
   /* config options here */
   reactCompiler: true,
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Frame-Options',
+            value: 'DENY',
+          },
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=(), browsing-topics=()',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains; preload',
+          },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was missing standard HTTP security headers, which could expose it to clickjacking, MIME-type sniffing, and other common web vulnerabilities.
🎯 Impact: Attackers could potentially embed the site in an iframe to steal clicks, sniff MIME types to execute malicious scripts, or access sensitive referrer information.
🔧 Fix: Configured `next.config.mjs` to inject standard security headers (`X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Strict-Transport-Security`) globally across all routes.
✅ Verification: Ran `pnpm build` and `pnpm lint` successfully. To verify, run the server and check the response headers in the browser's developer tools.

---
*PR created automatically by Jules for task [2066841848525086780](https://jules.google.com/task/2066841848525086780) started by @ANAGHAKTP*