### PR TITLE
⚡ Bolt: Improve LCP by prioritizing above-the-fold image

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+## 2024-11-21 - [LCP Image Optimization]
+**Learning:** Next.js Image component defaults to lazy loading, which can delay the Largest Contentful Paint (LCP) if the image is above the fold.
+**Action:** Always add the `priority` prop to above-the-fold images to preload them and improve perceived performance and LCP.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -54,6 +54,8 @@ export default function About() {
                                 src={aboutData.image}
                                 fill
                                 sizes="(max-width: 768px) 100vw, 50vw"
+                                priority
+                                /* ⚡ Bolt: Added priority to above-the-fold image to improve LCP */
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>


### PR DESCRIPTION
💡 **What**: Added the `priority` prop to the profile image in the `About.jsx` component.
🎯 **Why**: Next.js `<Image />` components are lazy-loaded by default. Since this image is critical content that appears prominently, lazy-loading it delays the Largest Contentful Paint (LCP).
📊 **Impact**: Faster LCP and perceived page load speed by forcing the browser to preload the image earlier in the page lifecycle.
🔬 **Measurement**: Verify by checking network tab or running lighthouse performance metrics. The image will load with a preload header and bypass standard lazy loading.

---
*PR created automatically by Jules for task [8238835613685190033](https://jules.google.com/task/8238835613685190033) started by @ANAGHAKTP*