### PR TITLE
🛡️ Sentinel: [security improvement] Add input length limits to contact form

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Input Length Limits on External Forms
+**Vulnerability:** Contact forms interacting with external APIs (like Google Forms) lacked input length limitations (`maxLength`).
+**Learning:** Even without a custom backend API, client-side input validation such as length limits is a critical defense-in-depth measure. It prevents excessively large payloads from being constructed, which could lead to client-side resource exhaustion or abuse of the external endpoint.
+**Prevention:** Always enforce reasonable `maxLength` attributes on all form inputs and textareas, regardless of whether the form submits to an internal or external endpoint.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -90,6 +90,7 @@ export default function Contact() {
                                         name={contactData.contactForm.fieldIds.name}
                                         type="text"
                                         required
+                                        maxLength={100}
                                         className="w-full bg-transparent border-b border-cream/20 py-4 focus:outline-none text-xl font-serif text-cream placeholder-cream/20"
                                         placeholder="Your Name"
                                     />
@@ -102,6 +103,7 @@ export default function Contact() {
                                         name={contactData.contactForm.fieldIds.email}
                                         type="email"
                                         required
+                                        maxLength={254}
                                         className="w-full bg-transparent border-b border-cream/20 py-4 focus:outline-none text-xl font-serif text-cream placeholder-cream/20"
                                         placeholder="your@email.com"
                                     />
@@ -115,6 +117,7 @@ export default function Contact() {
                                     name={contactData.contactForm.fieldIds.message}
                                     rows="1"
                                     required
+                                    maxLength={2000}
                                     className="w-full bg-transparent border-b border-cream/20 py-4 focus:outline-none text-xl font-serif text-cream resize-none overflow-hidden placeholder-cream/20"
                                     placeholder="Write something nice..."
                                     onInput={(e) => { e.target.style.height = 'auto'; e.target.style.height = e.target.scrollHeight + 'px'; }}


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: Missing input length limitations on the contact form interacting with an external API.
🎯 Impact: Attackers could submit excessively large payloads, potentially causing client-side resource exhaustion or abuse of the external Google Forms endpoint.
🔧 Fix: Added `maxLength` attributes to the `name` (100), `email` (254), and `message` (2000) inputs in `src/components/Contact.jsx`.
✅ Verification: Ensure the application builds correctly (`pnpm build`) and verify that users cannot enter text exceeding the specified limits in the contact form.

---
*PR created automatically by Jules for task [16704881496015450908](https://jules.google.com/task/16704881496015450908) started by @ANAGHAKTP*