### PR TITLE
🎨 Palette: Add accessible labels to circular text scroll indicators

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -136,8 +136,8 @@ export default function Hero() {
 
             {/* Scroll Down Indicator */}
             <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-20 flex flex-col items-center space-y-4 lg:hidden">
-                <a href="#about" className="w-24 h-24 rounded-full border border-cream/20 flex items-center justify-center relative group active:border-mustard/30">
-                    <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
+                <a href="#about" aria-label="Scroll down to About section" className="w-24 h-24 rounded-full border border-cream/20 flex items-center justify-center relative group active:border-mustard/30">
+                    <svg viewBox="0 0 100 100" aria-hidden="true" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
                         <path id="circlePathMobile" d="M 50, 50 m -35, 0 a 35,35 0 1,1 70,0 a 35,35 0 1,1 -70,0" fill="transparent" />
                         <text className="text-[8px] uppercase font-sans font-bold tracking-[0.18em] fill-cream">
                             <textPath href="#circlePathMobile" startOffset="0%">
@@ -146,7 +146,7 @@ export default function Hero() {
                         </text>
                     </svg>
                     <div className="w-7 h-7 rounded-full bg-mustard/10 flex items-center justify-center">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-mustard">
+                        <svg width="12" height="12" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-mustard">
                             <path d="M12 5v14M19 12l-7 7-7-7" />
                         </svg>
                     </div>
@@ -155,8 +155,8 @@ export default function Hero() {
 
             {/* Desktop Scroll Indicator */}
             <div className="absolute bottom-10 right-20 hidden lg:block z-20">
-                <a href="#about" className="w-32 h-32 rounded-full border border-cream/10 flex items-center justify-center relative group hover:border-mustard/30 transition-all duration-300">
-                    <svg viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
+                <a href="#about" aria-label="Scroll down to About section" className="w-32 h-32 rounded-full border border-cream/10 flex items-center justify-center relative group hover:border-mustard/30 transition-all duration-300">
+                    <svg viewBox="0 0 100 100" aria-hidden="true" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
                         <path id="circlePath" d="M 50, 50 m -38, 0 a 38,38 0 1,1 76,0 a 38,38 0 1,1 -76,0" fill="transparent" />
                         <text className="text-[7.5px] uppercase font-sans font-bold tracking-[0.2em] fill-cream group-hover:fill-mustard transition-colors duration-300">
                             <textPath href="#circlePath" startOffset="0%">
@@ -165,7 +165,7 @@ export default function Hero() {
                         </text>
                     </svg>
                     <div className="w-8 h-8 rounded-full bg-mustard/10 group-hover:bg-mustard/20 flex items-center justify-center transition-all duration-300">
-                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-mustard group-hover:translate-y-0.5 transition-transform duration-300">
+                        <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" className="text-mustard group-hover:translate-y-0.5 transition-transform duration-300">
                             <path d="M12 5v14M19 12l-7 7-7-7" />
                         </svg>
                     </div>


### PR DESCRIPTION
### 💡 What
Added `aria-label` to the scroll-down links in the Hero section and `aria-hidden="true"` to the decorative circular `<textPath>` SVGs.

### 🎯 Why
Screen readers interpret `<textPath>` literally, reading out "Scroll down • Scroll down • Scroll down •" as meaningless repetitive text. This change provides clear, concise meaning for the interactive elements while hiding the decorative visuals from assistive technologies.

### ♿ Accessibility
- Provides explicit purpose to anchor tags without visible text (`aria-label="Scroll down to About section"`).
- Hides purely decorative circular text from screen reader parsing (`aria-hidden="true"`).

---
*PR created automatically by Jules for task [4343887694755282424](https://jules.google.com/task/4343887694755282424) started by @ANAGHAKTP*