### PR TITLE
🛡️ Sentinel: [MEDIUM] Add client-side payload limits to external contact form

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-17 - Client-side form limits missing
+**Vulnerability:** External API forms (Google Forms integration) lack client-side input validation/limits.
+**Learning:** Due to the absence of a backend and the use of mode: "no-cors" with direct form submission, there are no payload size protections, which could lead to excessively large payload submissions resulting in resource exhaustion.
+**Prevention:** Always enforce client-side `maxLength` attributes on inputs and textareas that interact with external unvalidated endpoints.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -90,6 +90,7 @@ export default function Contact() {
                                         name={contactData.contactForm.fieldIds.name}
                                         type="text"
                                         required
+                                        maxLength={100}
                                         className="w-full bg-transparent border-b border-cream/20 py-4 focus:outline-none text-xl font-serif text-cream placeholder-cream/20"
                                         placeholder="Your Name"
                                     />
@@ -102,6 +103,7 @@ export default function Contact() {
                                         name={contactData.contactForm.fieldIds.email}
                                         type="email"
                                         required
+                                        maxLength={150}
                                         className="w-full bg-transparent border-b border-cream/20 py-4 focus:outline-none text-xl font-serif text-cream placeholder-cream/20"
                                         placeholder="your@email.com"
                                     />
@@ -115,6 +117,7 @@ export default function Contact() {
                                     name={contactData.contactForm.fieldIds.message}
                                     rows="1"
                                     required
+                                    maxLength={2000}
                                     className="w-full bg-transparent border-b border-cream/20 py-4 focus:outline-none text-xl font-serif text-cream resize-none overflow-hidden placeholder-cream/20"
                                     placeholder="Write something nice..."
                                     onInput={(e) => { e.target.style.height = 'auto'; e.target.style.height = e.target.scrollHeight + 'px'; }}


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The contact form interacting directly with an external Google Form endpoint lacked client-side input length limitations, allowing potentially massive payloads to be sent to the endpoint.
🎯 **Impact:** Malicious actors could submit excessively large text payloads to the external API, leading to potential resource exhaustion and DoS of the form integration script.
🔧 **Fix:** Enforced `maxLength` properties on the name (100), email (150), and message (2000) inputs in `src/components/Contact.jsx`.
✅ **Verification:** Verified by checking the updated attributes in the browser and ensuring form submission still completes successfully without introducing size-related regressions. Validated via `pnpm lint` and `pnpm build`.

---
*PR created automatically by Jules for task [11294783385160913156](https://jules.google.com/task/11294783385160913156) started by @ANAGHAKTP*