### PR TITLE
⚡ Bolt: Hoist hidden fields array to prevent reallocation

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -4,6 +4,11 @@ import { contactData } from "@/data/portfolio";
 
 import { useState } from 'react';
 
+// ⚡ Bolt: Hoisted static Object.entries computation to prevent array allocation on every re-render
+const hiddenFieldsEntries = contactData.contactForm.hiddenFields
+    ? Object.entries(contactData.contactForm.hiddenFields)
+    : [];
+
 export default function Contact() {
     const [status, setStatus] = useState('idle'); // idle, submitting, success, error
 
@@ -78,7 +83,7 @@ export default function Contact() {
                             className="space-y-8"
                         >
                             {/* Hidden Fields for Google Form */}
-                            {contactData.contactForm.hiddenFields && Object.entries(contactData.contactForm.hiddenFields).map(([name, value]) => (
+                            {hiddenFieldsEntries.map(([name, value]) => (
                                 <input key={name} type="hidden" name={name} value={value} />
                             ))}
 


### PR DESCRIPTION
💡 What: Hoisted the static computation of `Object.entries(contactData.contactForm.hiddenFields)` outside of the `Contact` component rendering function.

🎯 Why: To prevent an unnecessary array allocation (and `Object.entries` execution) on every re-render of the client-side `Contact` component.

📊 Impact: Reduces memory allocation and computation overhead slightly during user interactions or state updates within the form.

🔬 Measurement: Verify by running `pnpm lint` and `pnpm build` to ensure the project still builds correctly and passes linting. The change is isolated to the component rendering logic and preserves existing functionality exactly.

---
*PR created automatically by Jules for task [4729049630088257239](https://jules.google.com/task/4729049630088257239) started by @ANAGHAKTP*