### PR TITLE
🎨 Palette: Improve async submit button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-17 - Hidden circular text paths for screen readers
 **Learning:** Screen readers often parse circular SVG `<textPath>` text literally, which can result in confusing output for users depending on the text structure and context.
 **Action:** Always hide decorative circular SVG text (or SVGs acting as decorative text/icons within buttons/links) with `aria-hidden="true"` and provide a descriptive `aria-label` on the parent interactive element instead.
+
+## 2025-02-24 - Async Button Accessibility
+**Learning:** Using the native `disabled` attribute on an async form submission button causes screen readers to lose focus, interrupting the announcement of the loading state.
+**Action:** Use `aria-disabled="true"` paired with `aria-live="polite"` to maintain focus and reliably announce status changes like "Sending..." and "Sent!".

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -126,8 +126,9 @@ export default function Contact() {
                             </div>
                             <button
                                 type="submit"
-                                disabled={status === 'submitting'}
-                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 disabled:opacity-70 disabled:cursor-not-allowed"
+                                aria-disabled={status === 'submitting'}
+                                aria-live="polite"
+                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed"
                             >
                                 {status === 'idle' && <>Send Message <span className="material-icons">east</span></>}
                                 {status === 'submitting' && <>Sending... <span className="material-icons animate-spin">autorenew</span></>}


### PR DESCRIPTION
**What:** Replaced the native `disabled` attribute on the contact form submit button with `aria-disabled` and added `aria-live="polite"`.
**Why:** To prevent screen readers from losing focus when the button enters a loading state, ensuring status changes are communicated to the user.
**Before/After:** No visual change.
**Accessibility:** Screen readers now reliably announce "Sending..." and "Sent!" when the form is submitted instead of abruptly dropping focus.

---
*PR created automatically by Jules for task [1953411161807634221](https://jules.google.com/task/1953411161807634221) started by @ANAGHAKTP*