### PR TITLE
🛡️ Sentinel: [MEDIUM] Add CSP and disable X-Powered-By header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** External API forms (Google Forms integration) lack client-side input validation/limits.
 **Learning:** Due to the absence of a backend and the use of mode: "no-cors" with direct form submission, there are no payload size protections, which could lead to excessively large payload submissions resulting in resource exhaustion.
 **Prevention:** Always enforce client-side `maxLength` attributes on inputs and textareas that interact with external unvalidated endpoints.
+## 2024-05-24 - [Add Security Headers to Next.js App]
+**Vulnerability:** Missing `Content-Security-Policy` and exposing the `X-Powered-By` header in the Next.js app.
+**Learning:** Next.js uses an `X-Powered-By` header by default, which can leak framework information, and missing CSP headers make apps susceptible to XSS. Next.js supports custom headers directly in `next.config.mjs` including toggling off the powered by header.
+**Prevention:** In Next.js configuration `next.config.mjs`, use `poweredByHeader: false` and return a `Content-Security-Policy` header in the `headers()` async function that whitelists resources used by the app (like `docs.google.com` for forms and Vercel Analytics).

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,11 +2,16 @@
 const nextConfig = {
   /* config options here */
   reactCompiler: true,
+  poweredByHeader: false,
   async headers() {
     return [
       {
         source: "/:path*",
         headers: [
+          {
+            key: "Content-Security-Policy",
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://docs.google.com https://vitals.vercel-insights.com;",
+          },
           {
             key: "X-Frame-Options",
             value: "DENY",


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `Content-Security-Policy` and exposing the `X-Powered-By` header in the Next.js app.
🎯 Impact: Exposed framework information could aid targeted attacks, and lack of CSP leaves the site more vulnerable to potential Cross-Site Scripting (XSS) attacks.
🔧 Fix: Updated `next.config.mjs` to set `poweredByHeader: false` and added a `Content-Security-Policy` header in the `headers()` async function that whitelists required domains like Vercel Analytics and Google Forms.
✅ Verification: Ran `pnpm build` and `pnpm lint` successfully.

Changes kept under 50 lines. No new security dependencies added. No secrets exposed.

---
*PR created automatically by Jules for task [13411349233825407381](https://jules.google.com/task/13411349233825407381) started by @ANAGHAKTP*