### PR TITLE
⚡ Bolt: [performance improvement] Cap Next.js Image sizes to prevent oversized downloads on large screens

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+## 2024-05-24 - [Next.js Image Sizes on Large Screens]
+**Learning:** Using relative `vw` units like `50vw` in Next.js `<Image>` `sizes` props without a hard cap causes massive bandwidth waste on large, high-resolution screens (e.g., 4K monitors) when the image is inside a fixed-width container (like `max-w-7xl`). Next.js will generate and download needlessly large image variants (e.g., 2000px wide for a container that never exceeds 640px).
+**Action:** Always append a fixed pixel cap (e.g., `..., 640px`) to the `sizes` prop for images within fixed-width layout containers to prevent Next.js from generating and downloading oversized image variants on large displays.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -53,7 +53,7 @@ export default function About() {
                                 className="w-full h-full object-cover"
                                 src={aboutData.image}
                                 fill
-                                sizes="(max-width: 768px) 100vw, 50vw"
+                                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 384px"
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -28,7 +28,7 @@ export default function Projects() {
                                     className="w-full h-full object-cover transition-all duration-[1000ms] ease-out group-hover:scale-105 grayscale opacity-90 group-hover:opacity-100 group-hover:grayscale-0"
                                     src={project.image}
                                     fill
-                                    sizes="(max-width: 1024px) 100vw, 50vw"
+                                    sizes="(max-width: 1024px) 100vw, (max-width: 1280px) 50vw, 640px"
                                 />
                                 <div className="absolute inset-0 bg-[#c86d44]/5 mix-blend-multiply pointer-events-none group-hover:opacity-0 transition-opacity duration-500"></div>
                             </div>


### PR DESCRIPTION
💡 **What:** Added fixed pixel caps (`384px` for About, `640px` for Projects) to the Next.js `sizes` props in `<Image>` components that are inside fixed-width containers.

🎯 **Why:** Previously, `50vw` and `100vw` without limits caused Next.js to dynamically download massive, unoptimized image variants on ultra-wide or 4K monitors (e.g. 2000px wide image for a container bounded to max 640px). 

📊 **Impact:** Significantly reduces bandwidth consumption and initial load times on large displays by ensuring Next.js limits image variants to the maximum container dimensions.

🔬 **Measurement:** Verify by running the application locally on a large screen or simulating a 4K viewport. Open network tab and inspect downloaded image dimensions.

---
*PR created automatically by Jules for task [17795719358881648074](https://jules.google.com/task/17795719358881648074) started by @ANAGHAKTP*