### PR TITLE
🎨 Palette: Improve contact form accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-17 - Hidden circular text paths for screen readers
 **Learning:** Screen readers often parse circular SVG `<textPath>` text literally, which can result in confusing output for users depending on the text structure and context.
 **Action:** Always hide decorative circular SVG text (or SVGs acting as decorative text/icons within buttons/links) with `aria-hidden="true"` and provide a descriptive `aria-label` on the parent interactive element instead.
+
+## 2026-06-20 - Asynchronous Form Submit Buttons
+**Learning:** Using the native `disabled` attribute on submit buttons during asynchronous operations drops screen reader focus, creating a confusing experience.
+**Action:** Use `aria-disabled="true"` combined with `aria-live="polite"` on submit buttons during async submissions to maintain focus and reliably announce status changes, styling with Tailwind's native `aria-disabled:` modifiers.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -126,8 +126,10 @@ export default function Contact() {
                             </div>
                             <button
                                 type="submit"
-                                disabled={status === 'submitting'}
-                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 disabled:opacity-70 disabled:cursor-not-allowed"
+                                aria-disabled={status === 'submitting'}
+                                aria-live="polite"
+                                onClick={(e) => status === 'submitting' && e.preventDefault()}
+                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed"
                             >
                                 {status === 'idle' && <>Send Message <span className="material-icons">east</span></>}
                                 {status === 'submitting' && <>Sending... <span className="material-icons animate-spin">autorenew</span></>}


### PR DESCRIPTION
💡 What: Replaced the native `disabled` attribute on the contact form submit button with `aria-disabled="true"` during asynchronous submission, paired with `aria-live="polite"` and an `onClick` safeguard.
🎯 Why: Native disabled attributes abruptly drop screen reader focus when applied to active buttons. Using `aria-disabled` maintains focus and allows the button to politely announce state changes ("Sending...").
📸 Before/After: Visuals remained identical as we updated Tailwind classes from `disabled:opacity-70` to the native `aria-disabled:opacity-70`. 
♿ Accessibility: Improved screen reader experience by retaining focus and providing an immediate announcement during network requests.

---
*PR created automatically by Jules for task [11736662102747369399](https://jules.google.com/task/11736662102747369399) started by @ANAGHAKTP*