### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Content Security Policy and disable X-Powered-By

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@
 const nextConfig = {
   /* config options here */
   reactCompiler: true,
+  poweredByHeader: false,
   async headers() {
     return [
       {
@@ -26,6 +27,10 @@ const nextConfig = {
           {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; connect-src 'self' https://docs.google.com https://vitals.vercel-insights.com;",
           },
         ],
       },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing Content-Security-Policy (CSP) allows execution of unauthorized scripts and loading of unauthorized resources, increasing the risk of XSS and data injection attacks. Also, the `X-Powered-By` header leaks the technology stack, which might help attackers target specific vulnerabilities.
🎯 Impact: Attackers could potentially inject malicious scripts or exploit known Next.js vulnerabilities based on the technology stack leakage.
🔧 Fix: Added a robust `Content-Security-Policy` header in `next.config.mjs` that permits necessary resources (`docs.google.com`, `fonts.googleapis.com`, `va.vercel-scripts.com`, etc.) and explicitly disabled the `X-Powered-By` header.
✅ Verification: Ran `pnpm build` and `pnpm lint` locally with no errors. The Next.js config correctly applies these headers globally using `source: "/:path*"`.

---
*PR created automatically by Jules for task [7968067908325281431](https://jules.google.com/task/7968067908325281431) started by @ANAGHAKTP*