### PR TITLE
⚡ Bolt: Optimize Next.js Image sizes with pixel caps

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+## 2024-11-21 - [Next.js Image Sizes in Fixed Containers]
+**Learning:** Using purely relative `vw` units in Next.js `<Image>` `sizes` props inside fixed-width layout containers (like `max-w-7xl` or `max-w-sm`) will cause Next.js to generate and download unnecessarily oversized images on high-resolution displays.
+**Action:** Always append a fixed pixel cap (e.g., `sizes="..., 640px"`) corresponding to the maximum rendered size of the container to prevent oversized asset downloads on large screens.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -53,7 +53,8 @@ export default function About() {
                                 className="w-full h-full object-cover"
                                 src={aboutData.image}
                                 fill
-                                sizes="(max-width: 768px) 100vw, 50vw"
+                                // ⚡ Bolt: Added 384px cap to prevent oversized images on large displays
+                                sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 384px"
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -28,7 +28,8 @@ export default function Projects() {
                                     className="w-full h-full object-cover transition-all duration-[1000ms] ease-out group-hover:scale-105 grayscale opacity-90 group-hover:opacity-100 group-hover:grayscale-0"
                                     src={project.image}
                                     fill
-                                    sizes="(max-width: 1024px) 100vw, 50vw"
+                                    // ⚡ Bolt: Added 640px cap to prevent oversized images on large displays
+                                    sizes="(max-width: 1024px) 100vw, (max-width: 1280px) 50vw, 640px"
                                 />
                                 <div className="absolute inset-0 bg-[#c86d44]/5 mix-blend-multiply pointer-events-none group-hover:opacity-0 transition-opacity duration-500"></div>
                             </div>


### PR DESCRIPTION
💡 What: Added maximum pixel width caps (`384px` and `640px`) to the `sizes` attribute on Next.js `<Image>` components in `About.jsx` and `Projects.jsx`.
🎯 Why: Because these images reside inside fixed-width containers (`max-w-sm` and `max-w-7xl` respectively), using purely relative `vw` units caused Next.js to generate and download unnecessarily large images on high-resolution/ultra-wide displays.
📊 Impact: Reduces bandwidth usage and memory footprint on large displays by preventing the download of excessively high-resolution image variants.
🔬 Measurement: Verify by inspecting network requests on a large screen (> 1280px); the browser should now request the capped size rather than continuously requesting larger variants based on `vw`.

---
*PR created automatically by Jules for task [5081514686357215279](https://jules.google.com/task/5081514686357215279) started by @ANAGHAKTP*