### PR TITLE
🎨 Palette: Enhance submit button accessibility

### DIFF
--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -126,8 +126,10 @@ export default function Contact() {
                             </div>
                             <button
                                 type="submit"
-                                disabled={status === 'submitting'}
-                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 disabled:opacity-70 disabled:cursor-not-allowed"
+                                aria-disabled={status === 'submitting'}
+                                aria-live="polite"
+                                onClick={(e) => status === 'submitting' && e.preventDefault()}
+                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed"
                             >
                                 {status === 'idle' && <>Send Message <span className="material-icons">east</span></>}
                                 {status === 'submitting' && <>Sending... <span className="material-icons animate-spin">autorenew</span></>}


### PR DESCRIPTION
💡 **What:** Replaced the native `disabled` attribute with `aria-disabled` on the contact form submit button. Added `aria-live="polite"` for screen reader announcements and explicitly prevented clicks while submitting. Updated Tailwind classes to use the `aria-disabled:` modifier.
🎯 **Why:** To improve accessibility for screen reader users. When a button uses the native `disabled` attribute, it loses focus entirely, which can disorient users relying on assistive technology when the state transitions from submitting back to idle or success.
📸 **Before/After:** The visual appearance remains exactly the same due to utilizing Tailwind 4's native ARIA state modifiers (`aria-disabled:opacity-70`).
♿ **Accessibility:** Prevents focus loss during the submission state transition and proactively announces the changing state ("Sending...") to screen readers via `aria-live`.

---
*PR created automatically by Jules for task [18000253952846718120](https://jules.google.com/task/18000253952846718120) started by @ANAGHAKTP*