### PR TITLE
⚡ Bolt: [performance improvement] Next.js Image sizes pixel cap

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+## 2024-11-21 - [Next.js Image srcset optimization for fixed containers]
+**Learning:** When Next.js `<Image />` components use relative `vw` units in the `sizes` prop (e.g. `100vw, 50vw`), high-resolution displays (like 4K monitors) will request massively oversized source images because the browser calculates the viewport width regardless of whether the image is constrained by a CSS `max-width` container.
+**Action:** Always append a fixed pixel cap corresponding to the container's max width at larger breakpoints (e.g., `sizes="(max-width: 1024px) 100vw, 640px"`) to prevent Next.js from generating unnecessary high-resolution variants and save bandwidth.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -48,12 +48,13 @@ export default function About() {
                     {/* Profile Photo in Frame */}
                     <div className="relative w-full aspect-[3/4] rounded-2xl overflow-hidden shadow-2xl bg-forest p-3 border-4 border-forest">
                         <div className="relative w-full h-full rounded-xl overflow-hidden">
+                            {/* ⚡ Bolt: Fixed pixel cap in sizes prop to prevent Next.js from generating massively oversized images on 4K+ displays for this max-384px container */}
                             <Image
                                 alt="Anagha Profile"
                                 className="w-full h-full object-cover"
                                 src={aboutData.image}
                                 fill
-                                sizes="(max-width: 768px) 100vw, 50vw"
+                                sizes="(max-width: 768px) 100vw, 384px"
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -23,12 +23,13 @@ export default function Projects() {
                             
                             {/* Image Container */}
                             <div className="relative overflow-hidden rounded-[2.5rem] aspect-[16/10] bg-forest border border-black/5 shadow-lg">
+                                {/* ⚡ Bolt: Fixed pixel cap in sizes prop to prevent Next.js from generating massively oversized images on 4K+ displays for this grid item (max ~640px) */}
                                 <Image
                                     alt={project.title}
                                     className="w-full h-full object-cover transition-all duration-[1000ms] ease-out group-hover:scale-105 grayscale opacity-90 group-hover:opacity-100 group-hover:grayscale-0"
                                     src={project.image}
                                     fill
-                                    sizes="(max-width: 1024px) 100vw, 50vw"
+                                    sizes="(max-width: 1024px) 100vw, 640px"
                                 />
                                 <div className="absolute inset-0 bg-[#c86d44]/5 mix-blend-multiply pointer-events-none group-hover:opacity-0 transition-opacity duration-500"></div>
                             </div>


### PR DESCRIPTION
## 💡 What
Updated the `sizes` prop on Next.js `<Image />` components in `src/components/About.jsx` and `src/components/Projects.jsx` to append a fixed pixel cap (384px and 640px respectively) instead of relying solely on `50vw` for large screens.

## 🎯 Why
Next.js parses the `sizes` attribute to determine the dimensions of images to generate in the `srcset`. When an image is inside a fixed-width container but specifies a relative `vw` size, the browser on a 4K display will request a 1920px image even if the layout only allows the image to be 600px wide. Adding a pixel cap prevents fetching unnecessarily large files.

## 📊 Impact
Reduces LCP and bandwidth consumption for users on large and high-resolution monitors by downloading correctly sized images rather than full-resolution variants.

## 🔬 Measurement
Verified local frontend functionality using a Playwright script to ensure the correct layout and rendering is preserved. Next.js image optimizer will now serve correctly constrained images.

---
*PR created automatically by Jules for task [13437136341242959334](https://jules.google.com/task/13437136341242959334) started by @ANAGHAKTP*