### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Security Headers and disable Powered-By Header

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External API forms (Google Forms integration) lack client-side input validation/limits.
 **Learning:** Due to the absence of a backend and the use of mode: "no-cors" with direct form submission, there are no payload size protections, which could lead to excessively large payload submissions resulting in resource exhaustion.
 **Prevention:** Always enforce client-side `maxLength` attributes on inputs and textareas that interact with external unvalidated endpoints.
+
+## 2024-06-21 - Security Headers Missing
+**Vulnerability:** The application was missing basic security headers (like Content-Security-Policy) and leaking the Next.js tech stack.
+**Learning:** Even static/frontend-only Next.js applications require fundamental security headers in `next.config.mjs` to mitigate XSS and prevent fingerprinting. Next.js broadcasts its presence by default.
+**Prevention:** Always set `poweredByHeader: false` in `next.config.mjs` and configure standard security headers, particularly a restrictive Content-Security-Policy tailored to the app's external dependencies.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,7 @@
 const nextConfig = {
   /* config options here */
   reactCompiler: true,
+  poweredByHeader: false,
   async headers() {
     return [
       {
@@ -26,6 +27,10 @@ const nextConfig = {
           {
             key: "Permissions-Policy",
             value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://docs.google.com https://vitals.vercel-insights.com; img-src 'self' data:; frame-src 'self';",
           },
         ],
       },


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The application was missing a Content-Security-Policy header and was leaking tech stack information via the `X-Powered-By: Next.js` header.
🎯 Impact: Without a Content-Security-Policy, the app is more susceptible to Cross-Site Scripting (XSS) and data injection attacks. Leaking the tech stack makes the application easier to fingerprint for targeted attacks.
🔧 Fix: Configured `poweredByHeader: false` in `next.config.mjs` to remove the Next.js header. Added a `Content-Security-Policy` header allowing strictly the necessary domains for external scripts, styles, fonts, and form submissions (Google Fonts, Vercel Analytics, Google Forms).
✅ Verification: Ran `pnpm build` and `pnpm lint` to ensure the new configuration is syntactically valid and does not break the build process.

---
*PR created automatically by Jules for task [12549712777588039098](https://jules.google.com/task/12549712777588039098) started by @ANAGHAKTP*