### PR TITLE
🎨 Palette: Improve async form submission accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-17 - Hidden circular text paths for screen readers
 **Learning:** Screen readers often parse circular SVG `<textPath>` text literally, which can result in confusing output for users depending on the text structure and context.
 **Action:** Always hide decorative circular SVG text (or SVGs acting as decorative text/icons within buttons/links) with `aria-hidden="true"` and provide a descriptive `aria-label` on the parent interactive element instead.
+## 2026-06-22 - Async Form Submit Accessibility
+**Learning:** Using the native `disabled` attribute on submit buttons during async operations causes screen readers to lose focus, creating a confusing experience.
+**Action:** Use semantic `aria-disabled` combined with `aria-live="polite"` to maintain focus. Additionally, ensure you prevent default submission behavior (e.g., via `onClick`) when `aria-disabled` is true, and update CSS state modifiers to use `aria-disabled:` instead of `disabled:`.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -126,8 +126,10 @@ export default function Contact() {
                             </div>
                             <button
                                 type="submit"
-                                disabled={status === 'submitting'}
-                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 disabled:opacity-70 disabled:cursor-not-allowed"
+                                aria-disabled={status === 'submitting'}
+                                aria-live="polite"
+                                onClick={(e) => status === 'submitting' && e.preventDefault()}
+                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed"
                             >
                                 {status === 'idle' && <>Send Message <span className="material-icons">east</span></>}
                                 {status === 'submitting' && <>Sending... <span className="material-icons animate-spin">autorenew</span></>}


### PR DESCRIPTION
💡 What: Replaced native `disabled` attribute with semantic `aria-disabled="true"` and `aria-live="polite"` on the Contact form submit button, accompanied by manual `e.preventDefault()` behavior handling.
🎯 Why: Using the native `disabled` attribute on submit buttons during async operations causes screen readers to lose focus, confusing users relying on assistive technologies.
📸 Before/After: Visuals remained identical as Tailwind classes were updated from `disabled:` to `aria-disabled:`.
♿ Accessibility: Maintains screen reader focus and announces state changes ("Sending...") instead of silently dropping focus when disabled.

---
*PR created automatically by Jules for task [17103288240661146457](https://jules.google.com/task/17103288240661146457) started by @ANAGHAKTP*