### PR TITLE
🎨 Palette: Improve form submission accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-17 - Hidden circular text paths for screen readers
 **Learning:** Screen readers often parse circular SVG `<textPath>` text literally, which can result in confusing output for users depending on the text structure and context.
 **Action:** Always hide decorative circular SVG text (or SVGs acting as decorative text/icons within buttons/links) with `aria-hidden="true"` and provide a descriptive `aria-label` on the parent interactive element instead.
+## 2024-06-23 - Focus management for disabled buttons
+**Learning:** Natively disabling a submit button during asynchronous form submission drops screen reader focus to the document body because the button is removed from the focus order.
+**Action:** Prefer `aria-disabled="true"` combined with `aria-live="polite"` over native `disabled` attributes on submit buttons to maintain screen reader context, while manually preventing clicks using an `onClick` handler (`e.preventDefault()`).

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -126,8 +126,10 @@ export default function Contact() {
                             </div>
                             <button
                                 type="submit"
-                                disabled={status === 'submitting'}
-                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 disabled:opacity-70 disabled:cursor-not-allowed"
+                                aria-disabled={status === 'submitting'}
+                                aria-live="polite"
+                                onClick={(e) => status === 'submitting' && e.preventDefault()}
+                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed"
                             >
                                 {status === 'idle' && <>Send Message <span className="material-icons">east</span></>}
                                 {status === 'submitting' && <>Sending... <span className="material-icons animate-spin">autorenew</span></>}


### PR DESCRIPTION
💡 **What:** Replaced native `disabled` state on the Contact form submit button with `aria-disabled="true"`, added `aria-live="polite"`, and added an `onClick` handler to prevent repeated clicks. Updated Tailwind classes to use `aria-disabled` variants.
🎯 **Why:** Natively disabling a button while focused (e.g., immediately upon clicking "Submit") drops the screen reader's focus to the document body, breaking the user's context. By using `aria-disabled`, the element remains focusable and correctly announces its state change ("Sending...", "Sent!").
📸 **Before/After:** No visual differences. The button still appears disabled visually due to `aria-disabled:opacity-70 aria-disabled:cursor-not-allowed`.
♿ **Accessibility:** Prevents focus loss for keyboard and screen reader users during async form submission. Adds live region updates for the loading/success/error text.

---
*PR created automatically by Jules for task [10588815533932586836](https://jules.google.com/task/10588815533932586836) started by @ANAGHAKTP*