### PR TITLE
⚡ Bolt: [performance improvement] Add pixel caps to Image sizes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+
+## 2024-05-24 - [Next.js Image Component Oversizing]
+**Learning:** Using relative `vw` units in Next.js `<Image>` `sizes` props inside fixed-width CSS containers (like `max-w-sm` or `max-w-7xl`) causes the browser to download massively oversized images on high-resolution or ultra-wide displays.
+**Action:** Always append a fixed pixel cap (e.g., `sizes="..., 640px"`) to the `sizes` prop that corresponds to the maximum physical layout width of the container in the design to prevent Next.js from generating and serving unnecessarily large image files.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -48,12 +48,13 @@ export default function About() {
                     {/* Profile Photo in Frame */}
                     <div className="relative w-full aspect-[3/4] rounded-2xl overflow-hidden shadow-2xl bg-forest p-3 border-4 border-forest">
                         <div className="relative w-full h-full rounded-xl overflow-hidden">
+                            {/* ⚡ Bolt: Appended a fixed pixel cap (384px, derived from max-w-sm container) to sizes prop to prevent generating massively oversized images on high-resolution displays */}
                             <Image
                                 alt="Anagha Profile"
                                 className="w-full h-full object-cover"
                                 src={aboutData.image}
                                 fill
-                                sizes="(max-width: 768px) 100vw, 50vw"
+                                sizes="(max-width: 768px) 100vw, 384px"
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -23,12 +23,13 @@ export default function Projects() {
                             
                             {/* Image Container */}
                             <div className="relative overflow-hidden rounded-[2.5rem] aspect-[16/10] bg-forest border border-black/5 shadow-lg">
+                                {/* ⚡ Bolt: Appended a fixed pixel cap (640px, half of max-w-7xl) to sizes prop to prevent generating massively oversized images on high-resolution displays */}
                                 <Image
                                     alt={project.title}
                                     className="w-full h-full object-cover transition-all duration-[1000ms] ease-out group-hover:scale-105 grayscale opacity-90 group-hover:opacity-100 group-hover:grayscale-0"
                                     src={project.image}
                                     fill
-                                    sizes="(max-width: 1024px) 100vw, 50vw"
+                                    sizes="(max-width: 1024px) 100vw, (max-width: 1280px) 50vw, 640px"
                                 />
                                 <div className="absolute inset-0 bg-[#c86d44]/5 mix-blend-multiply pointer-events-none group-hover:opacity-0 transition-opacity duration-500"></div>
                             </div>


### PR DESCRIPTION
💡 **What:** Appended fixed pixel caps (`384px` and `640px`) to the `sizes` prop of `<Image>` components in `About.jsx` and `Projects.jsx`.

🎯 **Why:** To prevent Next.js from generating and downloading massively oversized images on ultra-wide displays when used in fixed-width containers.

📊 **Impact:** Reduces network bandwidth and improves load speed by fetching correctly-sized images.

🔬 **Measurement:** Verify the generated `srcset` size attributes using network devtools.

---
*PR created automatically by Jules for task [7039725680688020309](https://jules.google.com/task/7039725680688020309) started by @ANAGHAKTP*