### PR TITLE
🛡️ Sentinel: [security improvement] Fix external API call timeout and error logging

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** External API forms (Google Forms integration) lack client-side input validation/limits.
 **Learning:** Due to the absence of a backend and the use of mode: "no-cors" with direct form submission, there are no payload size protections, which could lead to excessively large payload submissions resulting in resource exhaustion.
 **Prevention:** Always enforce client-side `maxLength` attributes on inputs and textareas that interact with external unvalidated endpoints.
+
+## 2025-06-26 - External API Timeout & Error Logging
+**Vulnerability:** Hanging requests and verbose error logging on client
+**Learning:** `fetch` requests without explicit timeouts can hang indefinitely if the external service (like Google Forms) is slow or unreachable, potentially causing resource exhaustion on the client. Additionally, raw error objects logged to the console can expose internal stack traces or configuration details.
+**Prevention:** Always use `AbortController` to enforce timeouts on external API calls. Ensure that `clearTimeout` is called in a `finally` block to prevent memory leaks if the request succeeds. Use sanitized, generic error messages when logging to the console on the client side.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -15,19 +15,28 @@ export default function Contact() {
         const form = e.target;
         const formData = new FormData(form);
 
+        // 🛡️ Sentinel: Add timeout to prevent hanging requests and potential resource exhaustion
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 8000);
+
         try {
             await fetch(form.action, {
                 method: 'POST',
                 body: formData,
                 mode: 'no-cors',
+                signal: controller.signal,
             });
+
             setStatus('success');
             form.reset();
             setTimeout(() => setStatus('idle'), 3000);
         } catch (error) {
-            console.error('Submission error:', error);
+            // 🛡️ Sentinel: Avoid leaking full error objects/stack traces to the console
+            console.error('Submission failed. Check network or external service status.');
             setStatus('error');
             setTimeout(() => setStatus('idle'), 3000);
+        } finally {
+            clearTimeout(timeoutId);
         }
     };
     return (


### PR DESCRIPTION
🚨 Severity: LOW / MEDIUM
💡 Vulnerability: Hanging requests from external API calls and verbose error logging exposing stack traces on the client side.
🎯 Impact: Without a timeout, a slow or unreachable external service (like Google Forms) could cause the client application to hang indefinitely, potentially leading to resource exhaustion. Verbose error logs could expose internal details to an attacker.
🔧 Fix: Implemented an `AbortController` with an 8-second timeout for the Google Forms form submission fetch request. Replaced the raw error object logging with a safe, generic message. Ensured the timeout is cleared in a `finally` block.
✅ Verification: `pnpm build` and `pnpm lint` pass. Verified locally.

---
*PR created automatically by Jules for task [11377787178920733963](https://jules.google.com/task/11377787178920733963) started by @ANAGHAKTP*