### PR TITLE
🎨 Palette: [UX improvement] Enhance screen reader experience and remove false affordances

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-06-17 - Hidden circular text paths for screen readers
 **Learning:** Screen readers often parse circular SVG `<textPath>` text literally, which can result in confusing output for users depending on the text structure and context.
 **Action:** Always hide decorative circular SVG text (or SVGs acting as decorative text/icons within buttons/links) with `aria-hidden="true"` and provide a descriptive `aria-label` on the parent interactive element instead.
+## 2025-06-27 - Ligature Icon Accessibility
+**Learning:** Font-based ligature icons (like `material-icons`) read out their literal text values (e.g., "east", "check_circle") to screen readers if not properly hidden.
+**Action:** Always add `aria-hidden="true"` to `material-icons` ligatures (or any ligature-based icon implementation) and ensure the parent interactive element has a descriptive `aria-label` or visible text alternative.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -131,10 +131,10 @@ export default function Contact() {
                                 onClick={(e) => status === 'submitting' && e.preventDefault()}
                                 className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed"
                             >
-                                {status === 'idle' && <>Send Message <span className="material-icons">east</span></>}
-                                {status === 'submitting' && <>Sending... <span className="material-icons animate-spin">autorenew</span></>}
-                                {status === 'success' && <>Sent! <span className="material-icons text-green-700">check_circle</span></>}
-                                {status === 'error' && <>Error <span className="material-icons text-red-700">error</span></>}
+                                {status === 'idle' && <>Send Message <span className="material-icons" aria-hidden="true">east</span></>}
+                                {status === 'submitting' && <>Sending... <span className="material-icons animate-spin" aria-hidden="true">autorenew</span></>}
+                                {status === 'success' && <>Sent! <span className="material-icons text-green-700" aria-hidden="true">check_circle</span></>}
+                                {status === 'error' && <>Error <span className="material-icons text-red-700" aria-hidden="true">error</span></>}
                             </button>
                         </form>
                     </div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -19,7 +19,7 @@ export default function Projects() {
                 {/* Grid of Projects */}
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-16 gap-y-24">
                     {projectsData.map((project, index) => (
-                        <div key={index} className="group flex flex-col space-y-6 cursor-pointer">
+                        <div key={index} className="group flex flex-col space-y-6">
                             
                             {/* Image Container */}
                             <div className="relative overflow-hidden rounded-[2.5rem] aspect-[16/10] bg-forest border border-black/5 shadow-lg">

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -146,7 +146,7 @@ export default function Skills() {
                                         {HOBBIES.map((hobby) => (
                                             <div key={hobby.label} className="flex flex-col items-center space-y-4">
                                                 <div className="w-16 h-16 rounded-full border border-cream/10 flex items-center justify-center hover:border-mustard transition-colors">
-                                                    <span className="material-icons text-mustard">{hobby.icon}</span>
+                                                    <span className="material-icons text-mustard" aria-hidden="true">{hobby.icon}</span>
                                                 </div>
                                                 <span className="text-[10px] font-sans font-bold uppercase tracking-widest">{hobby.label}</span>
                                             </div>


### PR DESCRIPTION
💡 What: Added `aria-hidden="true"` to `material-icons` ligatures, and removed `cursor-pointer` class from static cards.
🎯 Why: Prevents screen readers from reading raw ligature text (like "east" and "check_circle"), and avoids false expectations of interactivity for non-clickable elements.
♿ Accessibility: Directly improves the semantic representation of elements for screen readers.

---
*PR created automatically by Jules for task [7735645498414015024](https://jules.google.com/task/7735645498414015024) started by @ANAGHAKTP*