### PR TITLE
⚡ Bolt: [performance improvement] Cap next/image sizes in fixed containers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+
+## 2026-06-28 - [Next.js Image sizes prop in bounded containers]
+**Learning:** Using relative `vw` units in the `next/image` `sizes` prop inside fixed-width layout containers causes the browser to download massively oversized images on high-resolution displays because the browser calculates `vw` based on the entire viewport, not the container.
+**Action:** When using the `sizes` prop in a layout with a max-width, always append a fixed pixel cap (e.g. `sizes="..., 640px"`) representing the container's maximum size to optimize bandwidth and LCP.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -48,12 +48,13 @@ export default function About() {
                     {/* Profile Photo in Frame */}
                     <div className="relative w-full aspect-[3/4] rounded-2xl overflow-hidden shadow-2xl bg-forest p-3 border-4 border-forest">
                         <div className="relative w-full h-full rounded-xl overflow-hidden">
+                            {/* ⚡ Bolt: Capped sizes prop to 384px to prevent Next.js from generating oversized images on high-res displays */}
                             <Image
                                 alt="Anagha Profile"
                                 className="w-full h-full object-cover"
                                 src={aboutData.image}
                                 fill
-                                sizes="(max-width: 768px) 100vw, 50vw"
+                                sizes="(max-width: 768px) 100vw, 384px"
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -23,12 +23,13 @@ export default function Projects() {
                             
                             {/* Image Container */}
                             <div className="relative overflow-hidden rounded-[2.5rem] aspect-[16/10] bg-forest border border-black/5 shadow-lg">
+                                {/* ⚡ Bolt: Capped sizes prop to 640px to prevent Next.js from generating oversized images on high-res displays */}
                                 <Image
                                     alt={project.title}
                                     className="w-full h-full object-cover transition-all duration-[1000ms] ease-out group-hover:scale-105 grayscale opacity-90 group-hover:opacity-100 group-hover:grayscale-0"
                                     src={project.image}
                                     fill
-                                    sizes="(max-width: 1024px) 100vw, 50vw"
+                                    sizes="(max-width: 1024px) 100vw, 640px"
                                 />
                                 <div className="absolute inset-0 bg-[#c86d44]/5 mix-blend-multiply pointer-events-none group-hover:opacity-0 transition-opacity duration-500"></div>
                             </div>


### PR DESCRIPTION
💡 What: Added fixed pixel caps (640px and 384px) to the `next/image` `sizes` props in `Projects.jsx` and `About.jsx`.\n🎯 Why: Next.js calculates relative `vw` units in `sizes` based on the viewport. When images are inside max-width containers, using `vw` causes browsers on high-resolution displays to request excessively large, unoptimized images.\n📊 Impact: Reduces maximum image download size and bandwidth on large screens, improving LCP and perceived performance.\n🔬 Measurement: Verified the code builds successfully and linting passes. The optimization will limit the size of image generated in the Next.js cache.

---
*PR created automatically by Jules for task [4044307745078712817](https://jules.google.com/task/4044307745078712817) started by @ANAGHAKTP*