### PR TITLE
🛡️ Sentinel: [security improvement] Prevent DOM-based form action hijacking

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -10,3 +10,7 @@
 **Vulnerability:** The application was passing the raw `error` object directly to `console.error` in the generic catch block for form submission.
 **Learning:** Raw error objects can contain internal stack traces, API keys (if poorly configured), or internal module names that shouldn't be exposed to the end-user via their browser console.
 **Prevention:** Sanitize error outputs in `catch` blocks before logging, using generic string messages for client-side environments.
+## 2025-02-27 - DOM-based form action hijacking
+**Vulnerability:** The application was using the `action` attribute from the DOM form element (`form.action`) for the `fetch` submission endpoint.
+**Learning:** Relying on DOM attributes for sensitive operations (like API endpoints) can be risky, as malicious scripts or browser extensions could modify the DOM (DOM-based form action hijacking) to exfiltrate user data to an attacker-controlled endpoint.
+**Prevention:** Always use a trusted, server-side or hardcoded configuration source for critical endpoint URLs in client-side code instead of trusting DOM state.

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -20,7 +20,8 @@ export default function Contact() {
         const timeoutId = setTimeout(() => controller.abort(), 8000);
 
         try {
-            await fetch(form.action, {
+            // 🛡️ Sentinel: Use trusted config action instead of DOM attribute to prevent DOM-based form action hijacking
+            await fetch(contactData.contactForm.action, {
                 method: 'POST',
                 body: formData,
                 mode: 'no-cors',


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: The contact form relied on the `action` attribute from the DOM element (`form.action`) as the submission endpoint for `fetch`.
🎯 Impact: This makes the endpoint vulnerable to DOM-based form action hijacking. Malicious scripts or browser extensions could modify the DOM to point the form submission to an attacker-controlled endpoint, exfiltrating the user's data.
🔧 Fix: Updated `Contact.jsx` to use the trusted configuration source (`contactData.contactForm.action`) instead of reading from the DOM attribute. Added an in-code comment explaining the security rationale.
✅ Verification: Ran `pnpm lint` and `pnpm build` to verify changes. The form now correctly uses the static configuration data.

---
*PR created automatically by Jules for task [6306765299296694147](https://jules.google.com/task/6306765299296694147) started by @ANAGHAKTP*