### PR TITLE
🎨 Palette: [UX improvement] Add focus visible styles for keyboard navigation

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2025-06-27 - Ligature Icon Accessibility
 **Learning:** Font-based ligature icons (like `material-icons`) read out their literal text values (e.g., "east", "check_circle") to screen readers if not properly hidden.
 **Action:** Always add `aria-hidden="true"` to `material-icons` ligatures (or any ligature-based icon implementation) and ensure the parent interactive element has a descriptive `aria-label` or visible text alternative.
+## 2025-06-28 - Missing Keyboard Navigation Focus States
+**Learning:** This application's interactive elements lacked clear `focus-visible` styles, rendering keyboard navigation extremely difficult for users navigating by `Tab`.
+**Action:** Consistently added `focus-visible` utility classes (e.g., `focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4`) to all interactive elements, matching their existing hover states to provide clear, reliable visual feedback for keyboard users.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -32,7 +32,7 @@ export default function About() {
                     <div className="pt-4">
                         <a
                             href={aboutData.linkedin || "#"}
-                            className="bg-black text-white px-10 py-5 rounded-badge font-bold text-sm uppercase tracking-widest flex items-center space-x-4 w-fit hover:bg-forest transition-colors"
+                            className="bg-black text-white px-10 py-5 rounded-badge font-bold text-sm uppercase tracking-widest flex items-center space-x-4 w-fit hover:bg-forest focus-visible:bg-forest focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4 transition-colors"
                         >
                             <span>Contact me</span>
                             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -54,7 +54,7 @@ export default function Contact() {
                     <div className="space-y-12 text-left">
                         <div className="space-y-4">
                             <h3 className="text-3xl font-serif font-bold text-mustard uppercase italic">Email</h3>
-                            <a href={`mailto:${contactData.email}`} className="text-4xl lg:text-5xl font-serif font-medium hover:text-mustard transition-colors break-all">
+                            <a href={`mailto:${contactData.email}`} className="text-4xl lg:text-5xl font-serif font-medium hover:text-mustard focus-visible:text-mustard focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-8 rounded-sm transition-colors break-all">
                                 {contactData.email}
                             </a>
                         </div>
@@ -65,7 +65,7 @@ export default function Contact() {
                                 {contactData.socials.map((social, index) => (
                                     <a
                                         key={index}
-                                        className="text-2xl font-sans font-bold hover:text-mustard transition-colors border-b-2 border-transparent hover:border-mustard pb-1"
+                                        className="text-2xl font-sans font-bold hover:text-mustard focus-visible:text-mustard focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-8 rounded-sm transition-colors border-b-2 border-transparent hover:border-mustard focus-visible:border-mustard pb-1"
                                         href={social.url}
                                         target="_blank"
                                         rel="noopener noreferrer"
@@ -137,7 +137,7 @@ export default function Contact() {
                                 aria-disabled={status === 'submitting'}
                                 aria-live="polite"
                                 onClick={(e) => status === 'submitting' && e.preventDefault()}
-                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 transition-all flex items-center justify-center gap-4 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed"
+                                className="w-full lg:w-max bg-mustard text-black font-bold py-6 px-16 rounded-badge text-lg hover:opacity-90 focus-visible:opacity-90 focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4 transition-all flex items-center justify-center gap-4 aria-disabled:opacity-70 aria-disabled:cursor-not-allowed"
                             >
                                 {status === 'idle' && <>Send Message <span className="material-icons" aria-hidden="true">east</span></>}
                                 {status === 'submitting' && <>Sending... <span className="material-icons animate-spin" aria-hidden="true">autorenew</span></>}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -122,8 +122,8 @@ export default function Hero() {
                         <div className="space-y-4 font-sans text-xs lg:text-sm font-bold tracking-widest uppercase self-start lg:self-end">
                             {FORMATTED_SOCIALS.map((social) => (
                                 <div key={social.platform} className="flex items-center space-x-6 group">
-                                    <span className="w-8 h-[1px] bg-cream/20 group-hover:w-12 group-hover:bg-mustard transition-all duration-300"></span>
-                                    <a href={social.url} target="_blank" rel="noopener noreferrer" className="hover:text-mustard transition-colors flex items-center">
+                                    <span className="w-8 h-[1px] bg-cream/20 group-hover:w-12 group-hover:bg-mustard group-focus-within:w-12 group-focus-within:bg-mustard transition-all duration-300"></span>
+                                    <a href={social.url} target="_blank" rel="noopener noreferrer" className="hover:text-mustard focus-visible:text-mustard focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4 rounded-sm transition-colors flex items-center">
                                         <span className="opacity-40 mr-1.5">{social.prefix}</span>
                                         <span>{social.handle}</span>
                                     </a>
@@ -136,7 +136,7 @@ export default function Hero() {
 
             {/* Scroll Down Indicator */}
             <div className="absolute bottom-12 left-1/2 -translate-x-1/2 z-20 flex flex-col items-center space-y-4 lg:hidden">
-                <a aria-label="Scroll down to about section" href="#about" className="w-24 h-24 rounded-full border border-cream/20 flex items-center justify-center relative group active:border-mustard/30">
+                <a aria-label="Scroll down to about section" href="#about" className="w-24 h-24 rounded-full border border-cream/20 flex items-center justify-center relative group active:border-mustard/30 focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4">
                     <svg aria-hidden="true" viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
                         <path id="circlePathMobile" d="M 50, 50 m -35, 0 a 35,35 0 1,1 70,0 a 35,35 0 1,1 -70,0" fill="transparent" />
                         <text className="text-[8px] uppercase font-sans font-bold tracking-[0.18em] fill-cream">
@@ -155,7 +155,7 @@ export default function Hero() {
 
             {/* Desktop Scroll Indicator */}
             <div className="absolute bottom-10 right-20 hidden lg:block z-20">
-                <a aria-label="Scroll down to about section" href="#about" className="w-32 h-32 rounded-full border border-cream/10 flex items-center justify-center relative group hover:border-mustard/30 transition-all duration-300">
+                <a aria-label="Scroll down to about section" href="#about" className="w-32 h-32 rounded-full border border-cream/10 flex items-center justify-center relative group hover:border-mustard/30 focus-visible:border-mustard/30 focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4 transition-all duration-300">
                     <svg aria-hidden="true" viewBox="0 0 100 100" className="absolute inset-0 w-full h-full animate-spin-slow pointer-events-none">
                         <path id="circlePath" d="M 50, 50 m -38, 0 a 38,38 0 1,1 76,0 a 38,38 0 1,1 -76,0" fill="transparent" />
                         <text className="text-[7.5px] uppercase font-sans font-bold tracking-[0.2em] fill-cream group-hover:fill-mustard transition-colors duration-300">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -8,11 +8,11 @@ export default function Navbar() {
             </div>
 
             <div className="hidden md:flex items-center space-x-12 font-sans text-xs font-bold uppercase tracking-widest">
-                <a href="#about" className="hover:opacity-60 transition-opacity">About me</a>
-                <a href="#projects" className="hover:opacity-60 transition-opacity">Work</a>
+                <a href="#about" className="hover:opacity-60 focus-visible:opacity-60 focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4 rounded-sm transition-all">About me</a>
+                <a href="#projects" className="hover:opacity-60 focus-visible:opacity-60 focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4 rounded-sm transition-all">Work</a>
                 <a
                     href="#contact"
-                    className="bg-mustard text-black px-8 py-3 rounded-badge hover:bg-orange-600 transition-all font-bold"
+                    className="bg-mustard text-black px-8 py-3 rounded-badge hover:bg-orange-600 focus-visible:bg-orange-600 focus-visible:outline-2 focus-visible:outline-mustard focus-visible:outline-offset-4 transition-all font-bold"
                 >
                     Get in touch!
                 </a>


### PR DESCRIPTION
💡 What: Added `focus-visible` styles to all interactive elements (links and buttons) across the site using existing Tailwind CSS classes.
🎯 Why: The site previously lacked distinct visual feedback for keyboard navigation, making it difficult for users relying on the `Tab` key to understand their current focus context. This change brings the site into compliance with accessibility best practices.
📸 Before/After: Before, keyboard focus had no visible indication. After, focusing on an element adds a clear mustard outline (matching hover states).
♿ Accessibility: Massively improves keyboard usability and WCAG 2.1 compliance for focus indicators.

---
*PR created automatically by Jules for task [15998932663764649922](https://jules.google.com/task/15998932663764649922) started by @ANAGHAKTP*