### PR TITLE
⚡ Bolt: [performance improvement] Cap Next.js Image sizes on high-res displays

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+## 2024-05-24 - Invalid HTML Syntax in Image sizes
+**Learning:** Appending a pixel cap fallback (e.g., `, 640px`) to a Next.js Image `sizes` string without ensuring all preceding items have a valid media condition (e.g., `(max-width: 1200px) 50vw`) results in invalid HTML syntax, as only the final fallback item can omit a media condition.
+**Action:** When updating `sizes`, always ensure all items except the final fallback specify a valid CSS media condition.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -48,12 +48,13 @@ export default function About() {
                     {/* Profile Photo in Frame */}
                     <div className="relative w-full aspect-[3/4] rounded-2xl overflow-hidden shadow-2xl bg-forest p-3 border-4 border-forest">
                         <div className="relative w-full h-full rounded-xl overflow-hidden">
+                            {/* ⚡ Bolt: Appended a 384px pixel cap to the sizes prop to prevent Next.js from generating excessively large images on high-res displays, as the container width is restricted by max-w-sm (384px) */}
                             <Image
                                 alt="Anagha Profile"
                                 className="w-full h-full object-cover"
                                 src={aboutData.image}
                                 fill
-                                sizes="(max-width: 768px) 100vw, 50vw"
+                                sizes="(max-width: 768px) 100vw, 384px"
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -23,12 +23,13 @@ export default function Projects() {
                             
                             {/* Image Container */}
                             <div className="relative overflow-hidden rounded-[2.5rem] aspect-[16/10] bg-forest border border-black/5 shadow-lg">
+                                {/* ⚡ Bolt: Appended a 640px pixel cap to the sizes prop to prevent Next.js from generating excessively large images on high-res displays, as the container width is restricted */}
                                 <Image
                                     alt={project.title}
                                     className="w-full h-full object-cover transition-all duration-[1000ms] ease-out group-hover:scale-105 grayscale opacity-90 group-hover:opacity-100 group-hover:grayscale-0"
                                     src={project.image}
                                     fill
-                                    sizes="(max-width: 1024px) 100vw, 50vw"
+                                    sizes="(max-width: 1024px) 100vw, (max-width: 1280px) 50vw, 640px"
                                 />
                                 <div className="absolute inset-0 bg-[#c86d44]/5 mix-blend-multiply pointer-events-none group-hover:opacity-0 transition-opacity duration-500"></div>
                             </div>


### PR DESCRIPTION
💡 What: Appended fixed pixel caps to the `sizes` prop of Next.js `<Image>` components in `Projects.jsx` and `About.jsx` and provided proper media conditions for preceding sizes.
🎯 Why: Unbounded `vw` values (like `50vw`) cause Next.js to request excessively large, unoptimized image resolutions on high-resolution displays or ultrawide monitors, even when the image container is physically constrained by a `max-width`.
📊 Impact: Reduces maximum image payload size on large displays. The `About` image is capped at `384px`, and `Projects` images are capped at `640px`.
🔬 Measurement: Run `pnpm build` to verify images generate standard caps. Monitor network tab on a high-DPI large display to see requested image sizes are restricted.

---
*PR created automatically by Jules for task [8029199367217195660](https://jules.google.com/task/8029199367217195660) started by @ANAGHAKTP*