### PR TITLE
⚡ Bolt: [performance improvement] Cap Next.js Image sizes to prevent massive image generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+## 2024-11-21 - Relative `vw` Units in Next.js Image Component
+**Learning:** Using relative `vw` units in Next.js `<Image>` `sizes` props inside fixed-width containers without a fallback can cause Next.js to generate massively oversized images (e.g. `3840px`), wasting bandwidth and memory.
+**Action:** Always append a fixed pixel fallback cap (e.g., `640px`) to prevent Next.js from generating massively oversized images. Crucially, ensure all preceding items in the `sizes` string have a valid media condition, as only the final fallback item can omit a media condition to avoid invalid HTML syntax.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -48,12 +48,13 @@ export default function About() {
                     {/* Profile Photo in Frame */}
                     <div className="relative w-full aspect-[3/4] rounded-2xl overflow-hidden shadow-2xl bg-forest p-3 border-4 border-forest">
                         <div className="relative w-full h-full rounded-xl overflow-hidden">
+                            {/* ⚡ Bolt: Added fixed pixel fallback to `sizes` to prevent Next.js from generating massively oversized images for relative vw units in fixed-width containers */}
                             <Image
                                 alt="Anagha Profile"
                                 className="w-full h-full object-cover"
                                 src={aboutData.image}
                                 fill
-                                sizes="(max-width: 768px) 100vw, 50vw"
+                                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 384px"
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -23,12 +23,13 @@ export default function Projects() {
                             
                             {/* Image Container */}
                             <div className="relative overflow-hidden rounded-[2.5rem] aspect-[16/10] bg-forest border border-black/5 shadow-lg">
+                                {/* ⚡ Bolt: Added fixed pixel fallback to `sizes` to prevent Next.js from generating massively oversized images for relative vw units in fixed-width containers */}
                                 <Image
                                     alt={project.title}
                                     className="w-full h-full object-cover transition-all duration-[1000ms] ease-out group-hover:scale-105 grayscale opacity-90 group-hover:opacity-100 group-hover:grayscale-0"
                                     src={project.image}
                                     fill
-                                    sizes="(max-width: 1024px) 100vw, 50vw"
+                                    sizes="(max-width: 1024px) 100vw, (max-width: 1280px) 50vw, 640px"
                                 />
                                 <div className="absolute inset-0 bg-[#c86d44]/5 mix-blend-multiply pointer-events-none group-hover:opacity-0 transition-opacity duration-500"></div>
                             </div>


### PR DESCRIPTION
💡 **What**: Added fixed pixel fallbacks to the `sizes` props of the `<Image />` components in `Projects.jsx` and `About.jsx`.
🎯 **Why**: Using relative `vw` units inside Next.js `sizes` strings without a fallback media condition causes Next.js to generate massive `srcSet` sizes on very wide high-res monitors (e.g. attempting to request a 1920px image for a container fixed at 600px).
📊 **Impact**: Reduces unnecessary bandwidth usage, prevents Next.js image optimization processing overhead, and lowers memory consumption on client devices viewing the site on ultrawide displays by capping maximum image widths to reasonable sizes corresponding to their `max-w` containers.
🔬 **Measurement**: Inspect the DOM using Developer Tools to see the generated `srcset` values; observe that the largest image URL generated respects the new explicit fallback caps (e.g., 640px for projects, 384px for the about image) rather than unbounded bounds relative to the viewport size.

---
*PR created automatically by Jules for task [17155329009116036881](https://jules.google.com/task/17155329009116036881) started by @ANAGHAKTP*