### PR TITLE
🎨 Palette: [UX improvement] Screen reader accessibility polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,7 @@
 ## 2025-06-27 - Ligature Icon Accessibility
 **Learning:** Font-based ligature icons (like `material-icons`) read out their literal text values (e.g., "east", "check_circle") to screen readers if not properly hidden.
 **Action:** Always add `aria-hidden="true"` to `material-icons` ligatures (or any ligature-based icon implementation) and ensure the parent interactive element has a descriptive `aria-label` or visible text alternative.
+
+## 2024-06-30 - Screen Reader Parsing of Fragmented Text
+**Learning:** Highly stylized typography (like splitting a word with SVGs) causes screen readers to read the text in broken fragments (e.g., "PORTF O LI O").
+**Action:** Always wrap visual text fragments in `aria-hidden="true"` and provide a complete `.sr-only` text alternative for assistive technologies to ensure clear pronunciation.

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -35,22 +35,25 @@ export default function Hero() {
                 {/* Giant Title: PORTFOLIO with Star in O */}
                 <div className="relative mb-12 select-none">
                     <h1 className="text-[12vw] lg:text-[9.5vw] font-serif font-bold uppercase tracking-tight leading-none text-cream flex items-center relative">
-                        PORTF
-                        <span className="relative inline-block">
-                            O
-                            <span className="absolute left-[38%] top-[32%] text-cream/40">
-                                <svg width="20" height="20" viewBox="0 0 100 100" className="w-[1.8vw] h-[1.8vw]">
-                                    <path d="M50 0 L58 42 L100 50 L58 58 L50 100 L42 58 L0 50 L42 42 Z" fill="currentColor" />
-                                </svg>
+                        <span className="sr-only">PORTFOLIO</span>
+                        <span aria-hidden="true" className="flex items-center">
+                            PORTF
+                            <span className="relative inline-block">
+                                O
+                                <span className="absolute left-[38%] top-[32%] text-cream/40">
+                                    <svg width="20" height="20" viewBox="0 0 100 100" className="w-[1.8vw] h-[1.8vw]">
+                                        <path d="M50 0 L58 42 L100 50 L58 58 L50 100 L42 58 L0 50 L42 42 Z" fill="currentColor" />
+                                    </svg>
+                                </span>
                             </span>
-                        </span>
-                        LI
-                        <span className="relative inline-block">
-                            O
-                            <span className="absolute left-[38%] top-[32%] text-cream/40">
-                                <svg width="20" height="20" viewBox="0 0 100 100" className="w-[1.8vw] h-[1.8vw]">
-                                    <path d="M50 0 L58 42 L100 50 L58 58 L50 100 L42 58 L0 50 L42 42 Z" fill="currentColor" />
-                                </svg>
+                            LI
+                            <span className="relative inline-block">
+                                O
+                                <span className="absolute left-[38%] top-[32%] text-cream/40">
+                                    <svg width="20" height="20" viewBox="0 0 100 100" className="w-[1.8vw] h-[1.8vw]">
+                                        <path d="M50 0 L58 42 L100 50 L58 58 L50 100 L42 58 L0 50 L42 42 Z" fill="currentColor" />
+                                    </svg>
+                                </span>
                             </span>
                         </span>
                     </h1>


### PR DESCRIPTION
💡 What: Wrapped the highly stylized "PORTFOLIO" title in `aria-hidden="true"` and added a complete, visually hidden `.sr-only` alternative for screen readers.
🎯 Why: The nested SVGs inside the "O"s caused screen readers to read the text in broken fragments (e.g., "PORTF O LI O"), leading to a confusing accessibility experience.
📸 Before/After: Visuals remain identical (verified with Playwright), but the underlying DOM is now accessible.
♿ Accessibility: Ensures assistive technologies pronounce the word "PORTFOLIO" cleanly without disruption from decorative SVGs.

---
*PR created automatically by Jules for task [11907964982113555424](https://jules.google.com/task/11907964982113555424) started by @ANAGHAKTP*