### PR TITLE
⚡ Bolt: [performance improvement] Add pixel caps to Next.js Image sizes

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2024-11-20 - Static Data in Components
 **Learning:** Hardcoding static dictionaries or array manipulation rules inside the render loop of functional React components can cause unnecessary allocation and computation during re-renders, impacting client-side performance.
 **Action:** Move static data objects, configuration mapping structures, and pure filtering or flattening operations that only rely on constant imports outside of the component function.
+## 2025-02-28 - Image sizes optimization
+**Learning:** When using relative vw units in Next.js Image sizes props inside fixed-width containers, you must append a fixed pixel fallback cap to prevent Next.js from generating massively oversized images.
+**Action:** Verify the layout structure explicitly before implementing caps, confirming the container classes via codebase inspection to avoid assuming standard Tailwind class constraints.

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -48,12 +48,13 @@ export default function About() {
                     {/* Profile Photo in Frame */}
                     <div className="relative w-full aspect-[3/4] rounded-2xl overflow-hidden shadow-2xl bg-forest p-3 border-4 border-forest">
                         <div className="relative w-full h-full rounded-xl overflow-hidden">
+                            {/* ⚡ Bolt: Added pixel cap fallback to `sizes` to prevent generating massive images since container is capped at max-w-sm (384px) */}
                             <Image
                                 alt="Anagha Profile"
                                 className="w-full h-full object-cover"
                                 src={aboutData.image}
                                 fill
-                                sizes="(max-width: 768px) 100vw, 50vw"
+                                sizes="(max-width: 768px) 100vw, 384px"
                             />
                             {/* Circle overlay as seen in mockup */}
                             <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-56 h-56 border-[25px] border-cream/10 rounded-full"></div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -23,12 +23,13 @@ export default function Projects() {
                             
                             {/* Image Container */}
                             <div className="relative overflow-hidden rounded-[2.5rem] aspect-[16/10] bg-forest border border-black/5 shadow-lg">
+                                {/* ⚡ Bolt: Added pixel cap fallback to `sizes` to prevent generating massive images on extra-wide screens since container maxes out at 7xl (1280px / 2 = 640px) */}
                                 <Image
                                     alt={project.title}
                                     className="w-full h-full object-cover transition-all duration-[1000ms] ease-out group-hover:scale-105 grayscale opacity-90 group-hover:opacity-100 group-hover:grayscale-0"
                                     src={project.image}
                                     fill
-                                    sizes="(max-width: 1024px) 100vw, 50vw"
+                                    sizes="(max-width: 1024px) 100vw, (max-width: 1280px) 50vw, 640px"
                                 />
                                 <div className="absolute inset-0 bg-[#c86d44]/5 mix-blend-multiply pointer-events-none group-hover:opacity-0 transition-opacity duration-500"></div>
                             </div>


### PR DESCRIPTION
💡 **What**: Added fixed pixel fallback caps to the `sizes` prop on the `<Image />` components in `Projects.jsx` and `About.jsx` based on their respective container restrictions.
🎯 **Why**: Using relative viewport units (`vw`) inside containers with maximum width limits (like `max-w-7xl` or `max-w-sm`) without a fixed fallback allows Next.js and the browser to incorrectly request excessively large images on very wide screens. Adding the fallback caps the requested size perfectly.
📊 **Impact**: Prevents oversized image requests on large displays, heavily reducing network load and speeding up First Contentful Paint.
🔬 **Measurement**: Verified the layout classes directly in code and successfully compiled the app. Checking network requests on a large display (e.g. 2000px+ width) will show images fetching up to the fallback cap instead of scaling with `vw`.

---
*PR created automatically by Jules for task [1006086354233005093](https://jules.google.com/task/1006086354233005093) started by @ANAGHAKTP*